### PR TITLE
Limits geometry buffering to Points so previews show appropriate zoom

### DIFF
--- a/Playgrounds/GEOSwiftMapKit.playground/Contents.swift
+++ b/Playgrounds/GEOSwiftMapKit.playground/Contents.swift
@@ -41,6 +41,9 @@ try! Point(wkt: "POINT(10 45)")
 // Create a POINT from its WKT representation.
 let point = try! Point(wkt: "POINT(10 45)")
 
+// Create a POLYGON from its WKT representation. Here: the Notre Dame cathedral building footprint
+let polygon = try! Polygon(wkt: "POLYGON ((2.349252343714653 48.85347829980472, 2.3489192520770246 48.853050271993254, 2.35034958675422 48.852599033892346, 2.350565116637 48.852593876862244, 2.3507845652447372 48.852712488426135, 2.3508237524963533 48.852874934242834, 2.350682678390797 48.85304253651725, 2.349252343714653 48.85347829980472))")
+
 // If the expected type is unknown, you can use Geometry(wkt:) and the
 // returned value will be one of the Geometry enum cases
 let geometry1 = try! Geometry(wkt: "POLYGON((35 10, 45 45.5, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))")

--- a/Sources/GEOSwiftMapKit/GEOSwift+MapKitQuickLook.swift
+++ b/Sources/GEOSwiftMapKit/GEOSwift+MapKitQuickLook.swift
@@ -11,7 +11,11 @@ protocol GEOSwiftQuickLook: CustomPlaygroundDisplayConvertible, GeometryConverti
 extension GEOSwiftQuickLook {
     public var playgroundDescription: Any {
         let defaultReturnValue: Any = (try? geometry.wkt()) ?? self
-        guard let buffered = try? geometry.buffer(by: 0.1)?.intersection(with: Polygon.world),
+        var bufferValue: Double = 0
+        if case .point = geometry {
+            bufferValue = 0.1
+        }
+        guard let buffered = try? geometry.buffer(by: bufferValue)?.intersection(with: Polygon.world),
             let region = try? MKCoordinateRegion(containing: buffered) else {
                 return defaultReturnValue
         }


### PR DESCRIPTION
Resolves https://github.com/GEOSwift/GEOSwiftMapKit/issues/10. 

The current playground implementation adds a buffer around Geometries when creating the region to show in the map. This can be seen when adding a small polygon to the playground, such as the Notre Dame cathedral building footprint (see below). This approach works well for Points where the buffer results in showing more geographic context. However, for polygons, especially small ones, this buffer adds too much geographic context, overwhelming the polygon itself. This PR limits the added buffer to Point types. Alternative strategies to resolve this issue could include adjusting the buffer by additional Geometry types.

Current: 
<img width="304" alt="Screenshot 2023-04-01 at 1 04 10 PM" src="https://user-images.githubusercontent.com/7976026/229306190-08ff31ed-fc6a-48f8-8e5d-9aec15ca3bda.png">
After PR: 
<img width="303" alt="Screenshot 2023-04-01 at 1 04 41 PM" src="https://user-images.githubusercontent.com/7976026/229306197-f4af0d82-f17a-4764-834d-d691d2e052c2.png">

